### PR TITLE
Fix path traversal vulnerability in GzipResourceEncodingProvider

### DIFF
--- a/services/src/main/java/org/keycloak/encoding/GzipResourceEncodingProvider.java
+++ b/services/src/main/java/org/keycloak/encoding/GzipResourceEncodingProvider.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.zip.GZIPOutputStream;
 
 public class GzipResourceEncodingProvider implements ResourceEncodingProvider {
@@ -38,7 +39,8 @@ public class GzipResourceEncodingProvider implements ResourceEncodingProvider {
 
         try {
             File encodedFile = new File(filePath);
-            if (!encodedFile.getCanonicalPath().startsWith(cacheDir.getCanonicalPath())) {
+            Path encodedFilePath = encodedFile.toPath().normalize();
+            if (!encodedFilePath.startsWith(cacheDir.toPath().normalize())) {
                 return null;
             }
 


### PR DESCRIPTION
Update `GzipResourceEncodingProvider` to prevent path traversal vulnerability.

* Replace `getCanonicalPath()` with `toPath().normalize()` on line 41 to check if the `encodedFile` path starts with the `cacheDir` path.
* Add import statement for `java.nio.file.Path`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Ali-Razmjoo/keycloak?shareId=fddb7e2c-9446-46d6-ae5b-81161ff209b3).