### PR TITLE
Fix SSRF vulnerability in ThemeResource, DefaultThemeManager, and FolderThemeProvider

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/ThemeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/ThemeResource.java
@@ -79,6 +79,10 @@ public class ThemeResource {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
 
+        if (!isValidThemeName(themeName)) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid theme name").build();
+        }
+
         try {
             String contentType = MimeTypeUtil.getContentType(path);
             Theme theme = session.theme().getTheme(themeName, Theme.Type.valueOf(themType.toUpperCase()));
@@ -130,6 +134,9 @@ public class ThemeResource {
         if (theme == null) {
             theTheme = session.theme().getTheme(type);
         } else {
+            if (!isValidThemeName(theme)) {
+                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid theme name").build();
+            }
             theTheme = session.theme().getTheme(theme, type);
         }
 
@@ -152,6 +159,10 @@ public class ThemeResource {
         }
 
         return Cors.builder().allowedOrigins("*").auth().add(Response.ok(result));
+    }
+
+    private boolean isValidThemeName(String themeName) {
+        return themeName != null && themeName.matches("^[a-zA-Z0-9_-]+$");
     }
 }
 

--- a/services/src/main/java/org/keycloak/theme/DefaultThemeManager.java
+++ b/services/src/main/java/org/keycloak/theme/DefaultThemeManager.java
@@ -68,6 +68,11 @@ public class DefaultThemeManager implements ThemeManager {
 
     @Override
     public Theme getTheme(String name, Theme.Type type) {
+        if (!isValidThemeName(name)) {
+            log.warnf("Invalid theme name: %s", name);
+            return null;
+        }
+
         Theme theme = factory.getCachedTheme(name, type);
         if (theme == null) {
             theme = loadTheme(name, type);
@@ -131,6 +136,11 @@ public class DefaultThemeManager implements ThemeManager {
     }
 
     private Theme findTheme(String name, Theme.Type type) {
+        if (!isValidThemeName(name)) {
+            log.warnf("Invalid theme name: %s", name);
+            return null;
+        }
+
         for (ThemeProvider p : getProviders()) {
             if (p.hasTheme(name, type)) {
                 try {
@@ -370,4 +380,7 @@ public class DefaultThemeManager implements ThemeManager {
         return providers;
     }
 
+    private boolean isValidThemeName(String themeName) {
+        return themeName != null && themeName.matches("^[a-zA-Z0-9_-]+$");
+    }
 }

--- a/services/src/main/java/org/keycloak/theme/FolderThemeProvider.java
+++ b/services/src/main/java/org/keycloak/theme/FolderThemeProvider.java
@@ -46,8 +46,12 @@ public class FolderThemeProvider implements ThemeProvider {
             return null;
         }
 
+        if (!isValidThemeName(name)) {
+            return null;
+        }
+
         File themeDir = getThemeDir(name, type);
-        return themeDir.isDirectory() ? new FolderTheme(themeDir, name, type) : null;
+        return themeDir != null && themeDir.isDirectory() ? new FolderTheme(themeDir, name, type) : null;
     }
 
     @Override
@@ -76,7 +80,7 @@ public class FolderThemeProvider implements ThemeProvider {
 
     @Override
     public boolean hasTheme(String name, Theme.Type type) {
-        return themesDir != null ? getThemeDir(name, type).isDirectory() : false;
+        return themesDir != null && isValidThemeName(name) ? getThemeDir(name, type).isDirectory() : false;
     }
 
     @Override
@@ -84,6 +88,10 @@ public class FolderThemeProvider implements ThemeProvider {
     }
 
     private File getThemeDir(String name, Theme.Type type) {
+        if (!isValidThemeName(name)) {
+            return null;
+        }
+
         File f = new File(themesDir, name + File.separator + type.name().toLowerCase());
         try {
             if (!f.getCanonicalPath().startsWith(themesDir.getCanonicalPath() + File.separator)) {
@@ -95,4 +103,7 @@ public class FolderThemeProvider implements ThemeProvider {
         return f;
     }
 
+    private boolean isValidThemeName(String themeName) {
+        return themeName != null && themeName.matches("^[a-zA-Z0-9_-]+$");
+    }
 }


### PR DESCRIPTION
Fix SSRF vulnerability in `ThemeResource`, `DefaultThemeManager`, and `FolderThemeProvider` classes.

* **ThemeResource.java**
  - Add validation for `themeName` parameter in `getResource` method.
  - Add validation for `theme` parameter in `getLocalizationTexts` method.
  - Add `isValidThemeName` method to validate theme names.

* **DefaultThemeManager.java**
  - Add validation for `name` parameter in `getTheme` and `findTheme` methods.
  - Add `isValidThemeName` method to validate theme names.

* **FolderThemeProvider.java**
  - Add validation for `name` parameter in `getTheme` and `getThemeDir` methods.
  - Add `isValidThemeName` method to validate theme names.

